### PR TITLE
Fix python3 <3.3

### DIFF
--- a/pbr/packaging.py
+++ b/pbr/packaging.py
@@ -16,6 +16,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import unicode_literals
+
 """
 Utilities with minimum-depends for use in setup.py
 """
@@ -270,7 +272,7 @@ def write_git_changelog(git_dir=None, dest_dir=os.path.curdir,
             first_line = True
             with io.open(new_changelog, "w",
                          encoding="utf-8") as changelog_file:
-                changelog_file.write(u"CHANGES\n=======\n\n")
+                changelog_file.write("CHANGES\n=======\n\n")
                 for line in changelog.split('\n'):
                     line_parts = line.split()
                     if len(line_parts) < 2:
@@ -291,9 +293,9 @@ def write_git_changelog(git_dir=None, dest_dir=os.path.curdir,
 
                         underline = len(tag) * '-'
                         if not first_line:
-                            changelog_file.write(u'\n')
+                            changelog_file.write('\n')
                         changelog_file.write(
-                            (u"%(tag)s\n%(underline)s\n\n" %
+                            ("%(tag)s\n%(underline)s\n\n" %
                              dict(tag=tag,
                                   underline=underline)))
 
@@ -301,7 +303,7 @@ def write_git_changelog(git_dir=None, dest_dir=os.path.curdir,
                         if msg.endswith("."):
                             msg = msg[:-1]
                         changelog_file.write(
-                            (u"* %(msg)s\n" % dict(msg=msg)))
+                            ("* %(msg)s\n" % dict(msg=msg)))
                     first_line = False
 
 


### PR DESCRIPTION
As python3 <3.3 doesn't support u'unicode' syntax, this fix is required to make pbr compile and run on those versions.
