### PR TITLE
Add the Python 3 trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
         License :: OSI Approved :: Apache Software License
         Operating System :: OS Independent
         Programming Language :: Python
+        Programming Language :: Python :: 3
 
 [files]
 packages =


### PR DESCRIPTION
Will allow pbr to be listed as a [Python 3 package on PyPI](https://pypi.python.org/pypi?:action=browse&c=533&show=all)
