### PR TITLE
Use `pip` to parse `requirements.txt` files.

### DIFF
--- a/pbr/packaging.py
+++ b/pbr/packaging.py
@@ -38,6 +38,7 @@ from setuptools.command import egg_info
 from setuptools.command import install
 from setuptools.command import install_scripts
 from setuptools.command import sdist
+from pip import req
 
 try:
     import cStringIO
@@ -101,8 +102,7 @@ def _any_existing(file_list):
 # Get requirements from the first file that exists
 def get_reqs_from_files(requirements_files):
     for requirements_file in _any_existing(requirements_files):
-        with open(requirements_file, 'r') as fil:
-            return fil.read().split('\n')
+        return list(req.parse_requirements(requirements_file))
     return []
 
 


### PR DESCRIPTION
The format for requirements files defined by `pip` allows lines that are not version specifiers:
- Comments (preceeded by a hash)
- Numerous `pip install` options, including `find-links` and `index`

See http://www.pip-installer.org/en/latest/reference/pip_install.html#requirements-file-format for details.

This change does not completely make `pbr` and `pip` behave identically: in particular, I've made no effort to parse `find-links` options out to add to `dependency_links` for setuptools. However, it does allow non-trivial requirements files for `pip` to work reasonably well with `pbr`.

(No, I don't know where `pip.req` is documented. It's not on the pip website. However, this endpoint has been pretty stable; I suspect it's fine to call it, since `pbr` already depends on `pip`.)
