### PR TITLE
Fix docs for git tag requirement

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -60,7 +60,7 @@ with the same number of commits since the release.
 
 .. note::
 
-   Note that `pbr` expects git tags to be signed, for using it to
+   Note that `pbr` expects git tags to be annotated, for using it to
    calculate version.
 
 The versions are expected to be compliant with :doc:`semver`.


### PR DESCRIPTION
Using `git describe` for version determination doesn’t
require signed tags, it will default to looking
for annotated tags.

As mentioned in http://git-scm.com/docs/git-describe using
the -all will cause it to include lightweight tags instead
of the default annotated tags
