### PR TITLE
Fix retrieval of commit data and most recent tag

### DIFF
--- a/pbr/packaging.py
+++ b/pbr/packaging.py
@@ -429,6 +429,7 @@ def _get_revno_and_last_tag(git_dir):
     of time.
     """
     changelog = git._iter_log_oneline(git_dir=git_dir)
+    changelog = changelog if changelog else []
     row_count = 0
     for row_count, (ignored, tag_set, ignored) in enumerate(changelog):
         version_tags = set()


### PR DESCRIPTION
``git._iter_log_online()`` returns None in some cases for instance when ``SKIP_WRITE_GIT_CHANGELOG`` is set to true. This needs to be handled in ``packaging._get_revno_and_last_tag()``.