### PR TITLE
Append short commit hash to dev versions.

### DIFF
--- a/pbr/packaging.py
+++ b/pbr/packaging.py
@@ -637,9 +637,10 @@ def _get_version_from_git_target(git_dir, target_version):
             dict(new=new_version, target=target_version))
     if distance == 0:
         return last_semver
-    new_dev = new_version.to_dev(distance)
+    short_sha = git.get_git_short_sha(git_dir)
+    new_dev = new_version.to_dev(distance, short_sha)
     if target_version is not None:
-        target_dev = target_version.to_dev(distance)
+        target_dev = target_version.to_dev(distance, short_sha)
         if target_dev > new_dev:
             return target_dev
     return new_dev

--- a/pbr/version.py
+++ b/pbr/version.py
@@ -39,7 +39,7 @@ class SemanticVersion(object):
 
     def __init__(
             self, major, minor=0, patch=0, prerelease_type=None,
-            prerelease=None, dev_count=None):
+            prerelease=None, dev_count=None, commit_short_sha=None):
         """Create a SemanticVersion.
 
         :param major: Major component of the version.
@@ -59,6 +59,7 @@ class SemanticVersion(object):
         if self._prerelease_type and not self._prerelease:
             self._prerelease = 0
         self._dev_count = dev_count or 0  # Normalise 0 to None.
+        self._commit_short_sha = commit_short_sha
 
     def __eq__(self, other):
         if not isinstance(other, SemanticVersion):
@@ -339,6 +340,9 @@ class SemanticVersion(object):
                 segments.append('.')
             segments.append('dev')
             segments.append(self._dev_count)
+            if self._commit_short_sha:
+                segments.append("-")
+                segments.append(self._commit_short_sha)
         return "".join(str(s) for s in segments)
 
     def release_string(self):
@@ -358,14 +362,15 @@ class SemanticVersion(object):
         """
         return self._long_version(None)
 
-    def to_dev(self, dev_count):
+    def to_dev(self, dev_count, commit_short_sha=None):
         """Return a development version of this semver.
 
         :param dev_count: The number of commits since the last release.
         """
         return SemanticVersion(
             self._major, self._minor, self._patch, self._prerelease_type,
-            self._prerelease, dev_count=dev_count)
+            self._prerelease, dev_count=dev_count,
+            commit_short_sha=commit_short_sha)
 
     def version_tuple(self):
         """Present the version as a version_info tuple.


### PR DESCRIPTION
Also make sure that the version remains valid. Adding a dot would make
it impossible to be installed by pip, which just ignores invalid
versions (e.g. more than 3 dots).

This commit is there for 2 reasons:

1. It matches what the documentation says. For some reason, pbr no
   longer does that.
2. It lets you have multiple branches with the same number of commits
   away from the latest release that can generate
   packages (e.g. wheels) in the same folder.