### PR TITLE
Expose setuptools option "python_requires"

### DIFF
--- a/pbr/util.py
+++ b/pbr/util.py
@@ -114,6 +114,7 @@ D1_D2_SETUP_ARGS = {
     # broken distutils requires
     "install_requires": ("metadata", "requires_dist"),
     "setup_requires": ("metadata", "setup_requires_dist"),
+    "python_requires": ("metadata",),
     "provides": ("metadata", "provides_dist"),  # **
     "obsoletes": ("metadata", "obsoletes_dist"),  # **
     "package_dir": ("files", 'packages_root'),


### PR DESCRIPTION
This small fix makes the setuptools option "python_requires" for defining Python version requirements available through setting "python-requires" in section metadata of setup.cfg. Fixes bug/feature-request [1735668](https://bugs.launchpad.net/pbr/+bug/1735668).

Feel free to push this to https://review.openstack.org/.