### PR TITLE
Replace imp with importlib.machinery

### DIFF
--- a/pbr/tests/test_packaging.py
+++ b/pbr/tests/test_packaging.py
@@ -40,7 +40,7 @@
 
 import email
 import email.errors
-import imp
+import importlib
 import os
 import re
 import sysconfig
@@ -1217,7 +1217,7 @@ def get_soabi():
         # NOTE(sigmavirus24): PyPy only added support for the SOABI config var
         # to sysconfig in 2015. That was well after 2.2.1 was published in the
         # Ubuntu 14.04 archive.
-        for suffix, _, _ in imp.get_suffixes():
+        for suffix, _, _ in importlib.machinery._SUFFIXES:
             if suffix.startswith('.pypy') and suffix.endswith('.so'):
                 soabi = suffix.split('.')[1]
                 break


### PR DESCRIPTION
The imp was removed in Python 3.12 [1]. This commit replaces `get_suffixes()` method call with `_SUFFIXES` array from `importlib.machinery`.

[1] https://github.com/python/cpython/issues/98040